### PR TITLE
Restore session tokens after reset

### DIFF
--- a/class-db-resetter.php
+++ b/class-db-resetter.php
@@ -7,6 +7,7 @@ if ( ! class_exists( 'DB_Resetter' ) ) :
     private $backup;
     private $blog_data;
     private $theme_plugin_data;
+    private $user_data;
     private $preserved;
     private $selected;
     private $reactivate;
@@ -126,8 +127,8 @@ if ( ! class_exists( 'DB_Resetter' ) ) :
     private function restore_backup() {
       $this->delete_backup_table_rows( $this->preserved );
       $this->restore_backup_tables( $this->backup );
-      $this->remove_user_session_tokens();
-      $this->reset_user_auth_cookie();
+      $this->set_user_session_tokens();
+      $this->restore_user_session_tokens();
       $this->assert_theme_plugin_data_needs_reset();
     }
 
@@ -156,17 +157,16 @@ if ( ! class_exists( 'DB_Resetter' ) ) :
       }
     }
 
-    private function remove_user_session_tokens() {
+    private function set_user_session_tokens() {
       if ( get_user_meta( $this->user->ID, 'session_tokens' ) ) {
-        delete_user_meta( $this->user->ID, 'session_tokens' );
+        $this->user_data = array(
+          'session_tokens' => get_user_meta( $this->user->ID, 'session_tokens', true )
+        );
       }
     }
 
-    private function reset_user_auth_cookie() {
-      if ( ! is_command_line() ) {
-        wp_clear_auth_cookie();
-        wp_set_auth_cookie( $this->user->ID );
-      }
+    private function restore_user_session_tokens() {
+      add_user_meta( $this->user->ID, 'session_tokens', $this->user_data['session_tokens'] );
     }
 
     private function assert_theme_plugin_data_needs_reset() {


### PR DESCRIPTION
fixes #14

It worked for me on my local testing environment. I am unsure if this will work on older versions of WordPress as I think the session management was only included recently.